### PR TITLE
Oprava drobné chyby v submit

### DIFF
--- a/ksp-klient.py
+++ b/ksp-klient.py
@@ -107,14 +107,11 @@ class KSPApiService:
             }, headers=self.headers)
 
     def submit(self, task: str, subtask: int, content: AnyStr) -> Response:
-        newHeaders = self.headers
-        newHeaders['Content-Type'] = 'text/plain'
-
         if type(content) == str:
             content = content.encode('utf-8')
 
         return requests.post(self.api_url + "tasks/submit",
-            data = content, headers=newHeaders,
+            data = content, headers={**self.headers, "Content-Type":"text/plain"},
             params = { "task" : task, "subtask" : subtask})
 
     def generate(self, task: str, subtask: int) -> Response:


### PR DESCRIPTION
Metoda `submit` přidává `Content-Type` do `self.headers` bez vytváření kopie, kvůli čemuž mají všechny další požadavky nastavený `Content-Type` (ale protože u všech ostatních požadavků nezáleží na `Content-Type`, tato chyba nezpůsobuje žádný pozorovatelný problém). Tato změna chybu opraví vytvořením kopie.

Pokud dojde ke změně licence repozitáře kvůli #1, tak souhlasím s použitím mých změn i pod novou licencí (nemusíte se mě ptát, jak by zákon jinak vyžadoval)